### PR TITLE
Fixing link to Go download

### DIFF
--- a/samples/Bookstore Demo/Bookstore-Demo-Instructions.md
+++ b/samples/Bookstore Demo/Bookstore-Demo-Instructions.md
@@ -10,7 +10,7 @@
 ## Downloads
 1.	[Download PostgreSQL](https://www.postgresql.org/download/windows/)
 
-2.	[Download Go](https://www.postgresql.org/download/windows/)
+2.	[Download Go](https://golang.org/dl/)
 
 3.	[Download Git](https://git-scm.com/download/win)
 


### PR DESCRIPTION
Currently link to Go download points to PG download page. Should be https://golang.org/dl/